### PR TITLE
Fix "riv_todo.rst:19: (WARNING/2) Bullet list ends without a blank line;...

### DIFF
--- a/doc/riv_todo.rst
+++ b/doc/riv_todo.rst
@@ -16,7 +16,8 @@ Bugs
 * **Publish**
 
   + Converting under windows have errors.
-  This may due to docutils could not executing correctly with vimrun.exe.
+
+    This may due to docutils could not executing correctly with vimrun.exe.
 * **Syntax**
 
   + The ``.. class:: Model(**Kwarg)`` will highlight all following document.


### PR DESCRIPTION
$ rst2html doc/riv_todo.rst a.html
riv_todo.rst:19: (WARNING/2) Bullet list ends without a blank line; unexpected unindent.

My patch fixed this issue.
