### PR TITLE
Escape spaces in file path

### DIFF
--- a/autoload/riv/publish.vim
+++ b/autoload/riv/publish.vim
@@ -289,7 +289,8 @@ fun! riv#publish#2(ft, file, path, browse) "{{{
         elseif a:ft == "odt"
             call s:sys(g:riv_ft_browser . ' '. file_path . ' &')
         else
-            call s:sys(g:riv_web_browser . ' '. file_path . ' &')
+            let escaped_path = substitute(file_path, ' ', '\\ ', 'g')
+            call s:sys(g:riv_web_browser . ' '. escaped_path . ' &')
         endif
     endif
 endfun "}}}


### PR DESCRIPTION
If you call riv#publish#file2 on a file with spaces in its name, Firefox gets confused and tries to open up each bit of the path. This occurs because the path is not escaped before passed to Firefox, and this simple substitution alleviates the issue.
