### PR TITLE
Adding new autonumbered list items should continue to be autonumbered

### DIFF
--- a/autoload/riv/list.vim
+++ b/autoload/riv/list.vim
@@ -365,7 +365,7 @@ fun! s:nr2num(n,type) "{{{
 endfun "}}}
 fun! s:next_list_num(num,...) "{{{
     let is_roman = a:0 ? a:1 : 0
-    if a:num == ''
+    if a:num == '' || a:num == '#'
         return a:num
     elseif a:num =~ '\d\+'
         return a:num+1


### PR DESCRIPTION
Previously, if a list item is like this:

```
#. Item one
#. Item two
```

and you attempt to add another list item, the new item looks like `0. Item three`.  This checks for the special `#` character and re-uses that if found.
