### PR TITLE
Don't enable full buffer spelling if being included for docstrings.

### DIFF
--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -9,13 +9,24 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 if g:riv_python_rst_hl == 1 
+    " Store the current syntax because python-mode set's it's syntax to pymode and
+    " not python
+    let g:_riv_stored_syntax = b:current_syntax
+    " Let the after/syntax/rst.vim know that this is not a full RST file, this
+    " way, it won't enable spelling on the whole file
+    let g:_riv_incluing_python_rst = 1
+
     unlet! b:current_syntax
     syn include @python_rst <sfile>:p:h:h:h/syntax/rst.vim
     syn include @python_rst <sfile>:p:h/rst.vim
     syn region  pythonRstString matchgroup=pythonString
         \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
-        \ contains=@python_rst
-    let b:current_syntax = "python"
+        \ contains=@python_rst,@Spell
+    " Restore the previous syntax
+    let b:current_syntax = g:_riv_stored_syntax
+    " Clear the temporary variable
+    unlet! g:_riv_stored_syntax
+    unlet! g:_riv_incluing_python_rst
 endif
 
 let &cpo = s:cpo_save

--- a/after/syntax/rst.vim
+++ b/after/syntax/rst.vim
@@ -108,7 +108,9 @@ for code in g:_riv_t.highlight_code
 endfor
 let b:current_syntax = "rst"
 
-if has("spell")
+if !exists("g:_riv_incluing_python_rst") && has("spell")
+    " Enable spelling on the whole file if we're not being included to parse
+    " docstrings
     syn spell toplevel
 endif
 


### PR DESCRIPTION
Fixes #77
