### PR TITLE
fix filtering of cached todo files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,13 @@ As The clickable is not stable. And with many voting to disable it.
 
 I revert to 0.77.
 
-There are other features should be done in this version.
+There are other features should be done in this version 0.79.
 
 But I don't have enough time currently.
 
-But You can give me advice here too.
+But You can give me advice here too. 
+
+And any advice for 0.8 is welcome.
 
 
 ----

--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -14,7 +14,7 @@ if g:riv_python_rst_hl == 1
     let g:_riv_stored_syntax = b:current_syntax
     " Let the after/syntax/rst.vim know that this is not a full RST file, this
     " way, it won't enable spelling on the whole file
-    let g:_riv_incluing_python_rst = 1
+    let g:_riv_including_python_rst = 1
 
     unlet! b:current_syntax
     syn include @python_rst <sfile>:p:h:h:h/syntax/rst.vim
@@ -26,7 +26,7 @@ if g:riv_python_rst_hl == 1
     let b:current_syntax = g:_riv_stored_syntax
     " Clear the temporary variable
     unlet! g:_riv_stored_syntax
-    unlet! g:_riv_incluing_python_rst
+    unlet! g:_riv_including_python_rst
 endif
 
 let &cpo = s:cpo_save

--- a/after/syntax/rst.vim
+++ b/after/syntax/rst.vim
@@ -108,7 +108,7 @@ for code in g:_riv_t.highlight_code
 endfor
 let b:current_syntax = "rst"
 
-if !exists("g:_riv_incluing_python_rst") && has("spell")
+if !exists("g:_riv_including_python_rst") && has("spell")
     " Enable spelling on the whole file if we're not being included to parse
     " docstrings
     syn spell toplevel

--- a/autoload/riv.vim
+++ b/autoload/riv.vim
@@ -72,6 +72,13 @@ fun! riv#get_latest() "{{{
     echo "Get Latest Verion at https://github.com/Rykka/riv.vim"
     echohl Normal
 endfun "}}}
+fun! riv#get_opt(name) "{{{
+    if exists("g:riv_".a:name)
+        return g:riv_{a:name}
+    else
+        return ''
+    endif
+endfun "}}}
 fun! riv#system(arg) abort "{{{
     " XXX: error in windows tmp files
     if exists("*vimproc#system")

--- a/autoload/riv/os.vim
+++ b/autoload/riv/os.vim
@@ -1,0 +1,27 @@
+
+let s:is_unix = has('unix')
+let s:is_windows = has('win16') || has('win32') || has('win64') || has('win95')
+let s:is_cygwin = has('win32unix')
+let s:is_mac = !s:is_windows && !s:is_cygwin
+      \ && (has('mac') || has('macunix') || has('gui_macvim') ||
+      \   (!isdirectory('/proc') && executable('sw_vers')))
+
+let s:is_linux = s:is_unix && !s:is_mac && !s:is_cygwin
+let s:is_ubuntu = s:is_linux && system("uname -a") =~? "ubuntu"
+let s:is_arch = s:is_linux && system("uname -a") =~ "ARCH"
+
+
+fun! riv#os#init() "{{{
+    if !exists("s:OS")
+        let s:OS = {
+                \ "is_unix"     :  s:is_unix,
+                \ "is_windows"  :  s:is_windows,
+                \ "is_cygwin"   :  s:is_cygwin,
+                \ "is_mac"      :  s:is_mac,
+                \ "is_linux"    :  s:is_linux,
+                \ "is_ubuntu"   :  s:is_ubuntu,
+                \ "is_arch"     :  s:is_arch
+                \}
+    endif
+    return s:OS
+endfun "}}}

--- a/autoload/riv/publish.vim
+++ b/autoload/riv/publish.vim
@@ -287,9 +287,11 @@ fun! s:single2(ft, file, browse) "{{{
         if a:ft == "latex"
             exe 'sp ' out_file
         elseif a:ft == "odt"
-            call s:sys(g:riv_ft_browser . ' '. shellescape(out_file) . ' &')
+            " call s:sys(g:riv_ft_browser . ' '. shellescape(out_file) . ' &')
+            call riv#util#browse(shellescape(out_file), g:riv_ft_browser)
         else
-            call s:sys(g:riv_web_browser . ' '. shellescape(out_file) . ' &')
+            " call s:sys(g:riv_web_browser . ' '. shellescape(out_file) . ' &')
+            call riv#util#browse(shellescape(out_file), g:riv_web_browser)
         endif
     endif
 endfun "}}}
@@ -361,17 +363,20 @@ fun! riv#publish#2(ft, file, path, browse) "{{{
         if a:ft == "latex"
             exe 'sp ' out_file
         elseif a:ft == "odt"
-            call s:sys(g:riv_ft_browser . ' '. out_file . ' &')
+            " call s:sys(g:riv_ft_browser . ' '. out_file . ' &')
+            call riv#util#browse(out_file, g:riv_ft_browser)
         else
             let escaped_path = substitute(out_file, ' ', '\\ ', 'g')
-            call s:sys(g:riv_web_browser . ' '. escaped_path . ' &')
+            " call s:sys(g:riv_web_browser . ' '. escaped_path . ' &')
+            call riv#util#browse(escaped_path, g:riv_web_browser)
         endif
     endif
 endfun "}}}
 
 fun! riv#publish#browse() "{{{
     let path = riv#path#build_ft('html') .  'index.html'
-    call s:sys(g:riv_web_browser . ' '. shellescape(path) . ' &')
+    " call s:sys(g:riv_web_browser . ' '. shellescape(path) . ' &')
+    call riv#util#browse(shellescape(path), g:riv_web_browser)
 endfun "}}}
 fun! riv#publish#open_path() "{{{
     exe 'sp ' riv#path#build_path()

--- a/autoload/riv/todo.vim
+++ b/autoload/riv/todo.vim
@@ -485,9 +485,13 @@ fun! riv#todo#todo_helper() "{{{
     let s:todo = riv#helper#new()
     let Todo = filter(copy(All),'v:val!~s:p.help_todo_done ')
     let Done = filter(copy(All),'v:val=~s:p.help_todo_done ') 
-    let Prior1 = filter(copy(All),'v:val=~s:p.help_prior1 ') 
-    let Prior2 = filter(copy(All),'v:val=~s:p.help_prior2 ') 
-    let Prior3 = filter(copy(All),'v:val=~s:p.help_prior3 ') 
+    let PriorInput = All
+    if exists('g:riv_todo_helper_ignore_done') && g:riv_todo_helper_ignore_done == 1
+       let PriorInput = Todo
+    endif
+    let Prior1 = filter(copy(PriorInput),'v:val=~s:p.help_prior1 ') 
+    let Prior2 = filter(copy(PriorInput),'v:val=~s:p.help_prior2 ') 
+    let Prior3 = filter(copy(PriorInput),'v:val=~s:p.help_prior3 ') 
     let s:todo.contents = [Todo,Done,All,Prior1,Prior2,Prior3]
     let prior_strs = map(range(3), '"#".s:t.prior_str[v:val]')
     let s:todo.contents_name = ['Todo', 'Done', 'All'] + prior_strs

--- a/autoload/riv/todo.vim
+++ b/autoload/riv/todo.vim
@@ -490,7 +490,7 @@ fun! riv#todo#todo_helper() "{{{
     let Prior3 = filter(copy(All),'v:val=~s:p.help_prior3 ') 
     let s:todo.contents = [Todo,Done,All,Prior1,Prior2,Prior3]
     let prior_strs = map(range(3), '"#".s:t.prior_str[v:val]')
-    let s:todo.contents_name = ['Todo', 'Done', 'ALl'] + prior_strs
+    let s:todo.contents_name = ['Todo', 'Done', 'All'] + prior_strs
     let s:todo.content_title = "Todos"
 
     let s:todo.maps['<Enter>'] = ':cal riv#todo#enter()<CR>'

--- a/autoload/riv/todo.vim
+++ b/autoload/riv/todo.vim
@@ -371,7 +371,7 @@ fun! s:cache_todo(force) "{{{
 
     let files = split(glob(root.'**/*'.riv#path#ext()))
     let b_path = riv#path#build_path()
-    let files = filter(files, ' riv#path#is_rel_to(b_path, v:val)')
+    let files = filter(files, '! riv#path#is_rel_to(b_path, v:val)')
 
     let todos = []
     let lines = []

--- a/autoload/riv/util.vim
+++ b/autoload/riv/util.vim
@@ -118,13 +118,7 @@ fun! riv#util#clear_highlight() "{{{
 endfun "}}}
 
 fun! riv#util#browse(url, ...) "{{{
-    if !exists("s:os")
-        if !exists("*os#init")
-            call riv#error(" os#init is needed, please install bundle 'rykka/os.vim' ")
-        else
-            let s:os = os#init()
-        endif
-    endif
+    let s:os = riv#os#init()
     let url = a:url
     " let url = url =~? '\v^%(https=|file|ftp|fap|gopher|mailto|news):' ? url : 'http://'. url
     let browser = get(a:000, 0, riv#get_opt('web_browser'))

--- a/autoload/riv/util.vim
+++ b/autoload/riv/util.vim
@@ -1,0 +1,149 @@
+"=============================================
+"  Plugin: riv
+"  File:   util.vim
+"  Author: Rykka<rykka@foxmail.com>
+"  Update: 2014-10-08
+"=============================================
+let s:cpo_save = &cpo
+set cpo-=C
+
+
+let s:V = vital#of('riv_vim')
+
+let s:File = s:V.import('System.File')
+
+
+fun! riv#util#open(...)
+    return call(s:File.open , a:000 , s:File)
+endfun
+fun! riv#util#edit(file) "{{{
+    exe 'e ' a:file
+endfun "}}}
+fun! riv#util#mkdir(path) "{{{
+    if !isdirectory(fnamemodify(a:path,':h'))
+        call mkdir(fnamemodify(a:path,':h'),'p')
+    endif
+endfun "}}}
+fun! riv#util#system(expr) abort "{{{
+    call s:system(a:expr)
+endfun "}}}
+
+fun! s:system(expr) abort "{{{
+    if exists("*vimproc#system")
+        call vimproc#system(a:expr)
+    else
+        call system(a:expr)
+    endif
+endfun "}}}
+
+fun! s:BEcho(Obj, ...) "{{{
+    let Obj = a:Obj
+    let idt = get(a:000, 0 , '')
+    let suf = get(a:000, 1 , '')
+    let sameline = get(a:000 , 2, 0)
+    if type(Obj) == type({})
+        call s:BEcho('{', idt,'',1)
+        for [Key, Var] in items(Obj)
+            call s:BEcho('"'.Key.'":', idt.'  ')
+            call s:BEcho(Var, idt.'  ', ',', 1)
+            unlet Var
+        endfor
+        call s:BEcho('}', idt, ',')
+    elseif type(Obj) == type([])
+        call s:BEcho('[', idt,'',1)
+        for Var in Obj
+            call s:BEcho(Var, idt.'  ', ',')
+            unlet Var
+        endfor
+        call s:BEcho(']', idt, ',')
+    elseif type(Obj) == type(function('tr'))
+        echon ' '.string(Obj).suf
+    else
+        if sameline
+            echon ' '.Obj.suf
+        else
+            echo idt.Obj.suf
+        endif
+    endif
+endfun "}}}
+
+fun! s:BEchon(Obj,...) "{{{
+    let Obj = a:Obj
+    let idt = get(a:000, 0 , '')
+    let suf = get(a:000, 1 , '')
+    echon ' '.Obj.suf
+endfun "}}}
+
+
+function! riv#util#BEcho(...) "{{{
+    return call('s:BEcho', a:000)
+endfunction "}}}
+
+fun! riv#util#nop(mapping) "{{{
+    " run the default action of mapping
+    let action = a:mapping
+    " replace back
+    let action = substitute(action,
+                \ '\[\([-0-9a-zA-Z]\+\)\]',
+                \ '\\<\1>','g')
+    exe 'exe "norm! '.action.'"'
+endfun "}}}
+
+fun! riv#util#fallback(mapping) "{{{
+    let m = a:mapping
+    let m = substitute(m,
+                \ '\[\([-0-9a-zA-Z]\+\)\]',
+                \ '<\1>','g')
+    let s:fbk = riv#get_opt('map_fallback')
+    if exists('s:fbk[m]')
+        if type(s:fbk[m]) == type(function('tr'))
+            call call(s:fbk[m], [])
+        elseif type(s:fbk[m]) == type('1')
+            " replace back
+            let k = s:fbk[m]
+            let k = substitute(k,
+                        \ '<\([-0-9a-zA-Z]\+\)>',
+                        \ '\\<\1>','g')
+            exe 'exe "norm! '.k.'"'
+        endif
+    else
+        call riv#util#nop(a:mapping)
+    endif
+    
+endfun "}}}
+
+fun! riv#util#clear_highlight() "{{{
+    2match none
+    redraw
+endfun "}}}
+
+fun! riv#util#browse(url, ...) "{{{
+    if !exists("s:os")
+        if !exists("*os#init")
+            call riv#error(" os#init is needed, please install bundle 'rykka/os.vim' ")
+        else
+            let s:os = os#init()
+        endif
+    endif
+    let url = a:url
+    " let url = url =~? '\v^%(https=|file|ftp|fap|gopher|mailto|news):' ? url : 'http://'. url
+    let browser = get(a:000, 0, riv#get_opt('web_browser'))
+    if s:os.is_mac
+        let browser = substitute(browser, '\<\w', '\U\0','g')
+        let cmd = 'open -a "'. browser .'"'. ' "'. url .'" &'
+    else
+        let cmd = browser. ' ' . url. ' &'
+    endif
+    echom cmd 
+    call system(cmd)
+endfun "}}}
+
+if expand('<sfile>:p') == expand('%:p') "{{{
+    call riv#util#open('~/Downloads/')
+    call riv#util#browse('www.163.com')
+    call riv#util#BEcho({1:1,2:[1,2,3,[1,2,3,4]]})
+endif "}}}
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/autoload/vital.vim
+++ b/autoload/vital.vim
@@ -1,0 +1,12 @@
+function! vital#of(name)
+  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital')
+  let file = split(files, "\n")
+  if empty(file)
+    throw 'vital: version file not found: ' . a:name
+  endif
+  let ver = readfile(file[0], 'b')
+  if empty(ver)
+    throw 'vital: invalid version file: ' . a:name
+  endif
+  return vital#_{substitute(ver[0], '\W', '', 'g')}#new()
+endfunction

--- a/autoload/vital/_riv_vim.vim
+++ b/autoload/vital/_riv_vim.vim
@@ -1,0 +1,304 @@
+let s:self_version = expand('<sfile>:t:r')
+
+" Note: The extra argument to globpath() was added in Patch 7.2.051.
+let s:globpath_third_arg = v:version > 702 || v:version == 702 && has('patch51')
+
+let s:loaded = {}
+
+function! s:import(name, ...)
+  let target = {}
+  let functions = []
+  for a in a:000
+    if type(a) == type({})
+      let target = a
+    elseif type(a) == type([])
+      let functions = a
+    endif
+    unlet a
+  endfor
+  let module = s:_import(a:name)
+  if empty(functions)
+    call extend(target, module, 'keep')
+  else
+    for f in functions
+      if has_key(module, f) && !has_key(target, f)
+        let target[f] = module[f]
+      endif
+    endfor
+  endif
+  return target
+endfunction
+
+function! s:load(...) dict
+  for arg in a:000
+    let [name; as] = type(arg) == type([]) ? arg[: 1] : [arg, arg]
+    let target = split(join(as, ''), '\W\+')
+    let dict = self
+    while 1 <= len(target)
+      let ns = remove(target, 0)
+      if !has_key(dict, ns)
+        let dict[ns] = {}
+      endif
+      if type(dict[ns]) == type({})
+        let dict = dict[ns]
+      else
+        unlet dict
+        break
+      endif
+    endwhile
+
+    if exists('dict')
+      call extend(dict, s:_import(name))
+    endif
+    unlet arg
+  endfor
+  return self
+endfunction
+
+function! s:unload()
+  let s:loaded = {}
+endfunction
+
+function! s:exists(name)
+  return s:_get_module_path(a:name) !=# ''
+endfunction
+
+function! s:search(pattern)
+  let paths = s:_vital_files(a:pattern)
+  let modules = sort(map(paths, 's:_file2module(v:val)'))
+  return s:_uniq(modules)
+endfunction
+
+function! s:expand_modules(entry, all)
+  if type(a:entry) == type([])
+    let candidates = s:_concat(map(copy(a:entry), 's:search(v:val)'))
+    if empty(candidates)
+      throw printf('vital: Any of module %s is not found', string(a:entry))
+    endif
+    if eval(join(map(copy(candidates), 'has_key(a:all, v:val)'), '+'))
+      let modules = []
+    else
+      let modules = [candidates[0]]
+    endif
+  else
+    let modules = s:search(a:entry)
+    if empty(modules)
+      throw printf('vital: Module %s is not found', a:entry)
+    endif
+  endif
+  call filter(modules, '!has_key(a:all, v:val)')
+  for module in modules
+    let a:all[module] = 1
+  endfor
+  return modules
+endfunction
+
+function! s:_import(name)
+  if type(a:name) == type(0)
+    return s:_build_module(a:name)
+  endif
+  let path = s:_get_module_path(a:name)
+  if path ==# ''
+    throw 'vital: module not found: ' . a:name
+  endif
+  let sid = s:_get_sid_by_script(path)
+  if !sid
+    try
+      execute 'source' fnameescape(path)
+    catch /^Vim\%((\a\+)\)\?:E484/
+      throw 'vital: module not found: ' . a:name
+    catch /^Vim\%((\a\+)\)\?:E127/
+      " Ignore.
+    endtry
+
+    let sid = s:_get_sid_by_script(path)
+  endif
+  return s:_build_module(sid)
+endfunction
+
+function! s:_get_module_path(name)
+  if s:_is_absolute_path(a:name) && filereadable(a:name)
+    return a:name
+  endif
+  if a:name ==# ''
+    let paths = [s:self_file]
+  elseif a:name =~# '\v^\u\w*%(\.\u\w*)*$'
+    let paths = s:_vital_files(a:name)
+  else
+    throw 'vital: Invalid module name: ' . a:name
+  endif
+
+  call filter(paths, 'filereadable(expand(v:val, 1))')
+  let path = get(paths, 0, '')
+  return path !=# '' ? path : ''
+endfunction
+
+function! s:_get_sid_by_script(path)
+  let path = s:_unify_path(a:path)
+  for line in filter(split(s:_redir('scriptnames'), "\n"),
+  \                  'stridx(v:val, s:self_version) > 0')
+    let list = matchlist(line, '^\s*\(\d\+\):\s\+\(.\+\)\s*$')
+    if !empty(list) && s:_unify_path(list[2]) ==# path
+      return list[1] - 0
+    endif
+  endfor
+  return 0
+endfunction
+
+function! s:_file2module(file)
+  let filename = fnamemodify(a:file, ':p:gs?[\\/]\+?/?')
+  let tail = matchstr(filename, 'autoload/vital/_\w\+/\zs.*\ze\.vim$')
+  return join(split(tail, '[\\/]\+'), '.')
+endfunction
+
+if filereadable(expand('<sfile>:r') . '.VIM')
+  " resolve() is slow, so we cache results.
+  let s:_unify_path_cache = {}
+  " Note: On windows, vim can't expand path names from 8.3 formats.
+  " So if getting full path via <sfile> and $HOME was set as 8.3 format,
+  " vital load duplicated scripts. Below's :~ avoid this issue.
+  function! s:_unify_path(path)
+    if has_key(s:_unify_path_cache, a:path)
+      return s:_unify_path_cache[a:path]
+    endif
+    let value = tolower(fnamemodify(resolve(fnamemodify(
+    \                   a:path, ':p')), ':~:gs?[\\/]\+?/?'))
+    let s:_unify_path_cache[a:path] = value
+    return value
+  endfunction
+else
+  function! s:_unify_path(path)
+    return resolve(fnamemodify(a:path, ':p:gs?[\\/]\+?/?'))
+  endfunction
+endif
+
+if s:globpath_third_arg
+  function! s:_runtime_files(path)
+    return split(globpath(&runtimepath, a:path, 1), "\n")
+  endfunction
+else
+  function! s:_runtime_files(path)
+    return split(globpath(&runtimepath, a:path), "\n")
+  endfunction
+endif
+
+let s:_vital_files_cache_runtimepath = ''
+let s:_vital_files_cache = []
+function! s:_vital_files(pattern)
+  if s:_vital_files_cache_runtimepath !=# &runtimepath
+    let path = printf('autoload/vital/%s/**/*.vim', s:self_version)
+    let s:_vital_files_cache = s:_runtime_files(path)
+    let mod = ':p:gs?[\\/]\+?/?'
+    call map(s:_vital_files_cache, 'fnamemodify(v:val, mod)')
+    let s:_vital_files_cache_runtimepath = &runtimepath
+  endif
+  let target = substitute(a:pattern, '\.', '/', 'g')
+  let target = substitute(target, '\*', '[^/]*', 'g')
+  let regexp = printf('autoload/vital/%s/%s.vim', s:self_version, target)
+  return filter(copy(s:_vital_files_cache), 'v:val =~# regexp')
+endfunction
+
+" Copy from System.Filepath
+if has('win16') || has('win32') || has('win64')
+  function! s:_is_absolute_path(path)
+    return a:path =~? '^[a-z]:[/\\]'
+  endfunction
+else
+  function! s:_is_absolute_path(path)
+    return a:path[0] ==# '/'
+  endfunction
+endif
+
+function! s:_build_module(sid)
+  if has_key(s:loaded, a:sid)
+    return copy(s:loaded[a:sid])
+  endif
+  let functions = s:_get_functions(a:sid)
+
+  let prefix = '<SNR>' . a:sid . '_'
+  let module = {}
+  for func in functions
+    let module[func] = function(prefix . func)
+  endfor
+  if has_key(module, '_vital_loaded')
+    let V = vital#{s:self_version}#new()
+    if has_key(module, '_vital_depends')
+      let all = {}
+      let modules =
+      \     s:_concat(map(module._vital_depends(),
+      \                   's:expand_modules(v:val, all)'))
+      call call(V.load, modules, V)
+    endif
+    try
+      call module._vital_loaded(V)
+    catch
+      " FIXME: Show an error message for debug.
+    endtry
+  endif
+  if !get(g:, 'vital_debug', 0)
+    call filter(module, 'v:key =~# "^\\a"')
+  endif
+  let s:loaded[a:sid] = module
+  return copy(module)
+endfunction
+
+if exists('+regexpengine')
+  function! s:_get_functions(sid)
+    let funcs = s:_redir(printf("function /\\%%#=2^\<SNR>%d_", a:sid))
+    let map_pat = '<SNR>' . a:sid . '_\zs\w\+'
+    return map(split(funcs, "\n"), 'matchstr(v:val, map_pat)')
+  endfunction
+else
+  function! s:_get_functions(sid)
+    let prefix = '<SNR>' . a:sid . '_'
+    let funcs = s:_redir('function')
+    let filter_pat = '^\s*function ' . prefix
+    let map_pat = prefix . '\zs\w\+'
+    return map(filter(split(funcs, "\n"),
+    \          'stridx(v:val, prefix) > 0 && v:val =~# filter_pat'),
+    \          'matchstr(v:val, map_pat)')
+  endfunction
+endif
+
+if exists('*uniq')
+  function! s:_uniq(list)
+    return uniq(a:list)
+  endfunction
+else
+  function! s:_uniq(list)
+    let i = len(a:list) - 1
+    while 0 < i
+      if a:list[i] ==# a:list[i - 1]
+        call remove(a:list, i)
+        let i -= 2
+      else
+        let i -= 1
+      endif
+    endwhile
+    return a:list
+  endfunction
+endif
+
+function! s:_concat(lists)
+  let result_list = []
+  for list in a:lists
+    let result_list += list
+  endfor
+  return result_list
+endfunction
+
+function! s:_redir(cmd)
+  let [save_verbose, save_verbosefile] = [&verbose, &verbosefile]
+  set verbose=0 verbosefile=
+  redir => res
+    silent! execute a:cmd
+  redir END
+  let [&verbose, &verbosefile] = [save_verbose, save_verbosefile]
+  return res
+endfunction
+
+function! vital#{s:self_version}#new()
+  return s:_import('')
+endfunction
+
+let s:self_file = s:_unify_path(expand('<sfile>'))

--- a/autoload/vital/_riv_vim/System/File.vim
+++ b/autoload/vital/_riv_vim/System/File.vim
@@ -1,0 +1,237 @@
+" Utilities for file copy/move/mkdir/etc.
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:is_unix = has('unix')
+let s:is_windows = has('win16') || has('win32') || has('win64') || has('win95')
+let s:is_cygwin = has('win32unix')
+let s:is_mac = !s:is_windows && !s:is_cygwin
+      \ && (has('mac') || has('macunix') || has('gui_macvim') ||
+      \   (!isdirectory('/proc') && executable('sw_vers')))
+" As of 7.4.122, the system()'s 1st argument is converted internally by Vim.
+" Note that Patch 7.4.122 does not convert system()'s 2nd argument and
+" return-value. We must convert them manually.
+let s:need_trans = v:version < 704 || (v:version == 704 && !has('patch122'))
+
+" Open a file.
+function! s:open(filename) "{{{
+  let filename = fnamemodify(a:filename, ':p')
+
+  " Detect desktop environment.
+  if s:is_windows
+    " For URI only.
+    if s:need_trans
+      let filename = iconv(filename, &encoding, 'char')
+    endif
+    silent execute '!start rundll32 url.dll,FileProtocolHandler' filename
+  elseif s:is_cygwin
+    " Cygwin.
+    call system(printf('%s %s', 'cygstart',
+          \ shellescape(filename)))
+  elseif executable('xdg-open')
+    " Linux.
+    call system(printf('%s %s &', 'xdg-open',
+          \ shellescape(filename)))
+  elseif exists('$KDE_FULL_SESSION') && $KDE_FULL_SESSION ==# 'true'
+    " KDE.
+    call system(printf('%s %s &', 'kioclient exec',
+          \ shellescape(filename)))
+  elseif exists('$GNOME_DESKTOP_SESSION_ID')
+    " GNOME.
+    call system(printf('%s %s &', 'gnome-open',
+          \ shellescape(filename)))
+  elseif executable('exo-open')
+    " Xfce.
+    call system(printf('%s %s &', 'exo-open',
+          \ shellescape(filename)))
+  elseif s:is_mac && executable('open')
+    " Mac OS.
+    call system(printf('%s %s &', 'open',
+          \ shellescape(filename)))
+  else
+    " Give up.
+    throw 'Not supported.'
+  endif
+endfunction "}}}
+
+
+" Move a file.
+" Dispatch s:move_exe() or s:move_vim().
+" FIXME: Currently s:move_vim() does not support
+" moving a directory.
+function! s:move(src, dest) "{{{
+  if s:_has_move_exe() || isdirectory(a:src)
+    return s:move_exe(a:src, a:dest)
+  else
+    return s:move_vim(a:src, a:dest)
+  endif
+endfunction "}}}
+
+if s:is_unix
+  function! s:_has_move_exe()
+    return executable('mv')
+  endfunction
+elseif s:is_windows
+  function! s:_has_move_exe()
+    return 1
+  endfunction
+else
+  function! s:_has_move_exe()
+    throw 'vital: System.File._has_move_exe(): your platform is not supported'
+  endfunction
+endif
+
+" Move a file.
+" Implemented by external program.
+if s:is_unix
+  function! s:move_exe(src, dest)
+    if !s:_has_move_exe() | return 0 | endif
+    let [src, dest] = [a:src, a:dest]
+    call system('mv ' . shellescape(src) . ' ' . shellescape(dest))
+    return !v:shell_error
+  endfunction
+elseif s:is_windows
+  function! s:move_exe(src, dest)
+    if !s:_has_move_exe() | return 0 | endif
+    let [src, dest] = [a:src, a:dest]
+    " Normalize successive slashes to one slash.
+    let src  = substitute(src, '[/\\]\+', '\', 'g')
+    let dest = substitute(dest, '[/\\]\+', '\', 'g')
+    " src must not have trailing '\'.
+    let src  = substitute(src, '\\$', '', 'g')
+    " All characters must be encoded to system encoding.
+    if s:need_trans
+      let src  = iconv(src, &encoding, 'char')
+      let dest = iconv(dest, &encoding, 'char')
+    endif
+    let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
+    call system(cmd_exe . 'move /y ' . src  . ' ' . dest)
+    return !v:shell_error
+  endfunction
+else
+  function! s:move_exe()
+    throw 'vital: System.File.move_exe(): your platform is not supported'
+  endfunction
+endif
+
+" Move a file.
+" Implemented by pure Vim script.
+function! s:move_vim(src, dest) "{{{
+  return !rename(a:src, a:dest)
+endfunction "}}}
+
+" Copy a file.
+" Dispatch s:copy_exe() or s:copy_vim().
+function! s:copy(src, dest) "{{{
+  if s:_has_copy_exe()
+    return s:copy_exe(a:src, a:dest)
+  else
+    return s:copy_vim(a:src, a:dest)
+  endif
+endfunction "}}}
+
+if s:is_unix
+  function! s:_has_copy_exe()
+    return executable('cp')
+  endfunction
+elseif s:is_windows
+  function! s:_has_copy_exe()
+    return 1
+  endfunction
+else
+  function! s:_has_copy_exe()
+    throw 'vital: System.File._has_copy_exe(): your platform is not supported'
+  endfunction
+endif
+
+" Copy a file.
+" Implemented by external program.
+if s:is_unix
+  function! s:copy_exe(src, dest)
+    if !s:_has_copy_exe() | return 0 | endif
+    let [src, dest] = [a:src, a:dest]
+    call system('cp ' . shellescape(src) . ' ' . shellescape(dest))
+    return !v:shell_error
+  endfunction
+elseif s:is_windows
+  function! s:copy_exe(src, dest)
+    if !s:_has_copy_exe() | return 0 | endif
+    let [src, dest] = [a:src, a:dest]
+    let src  = substitute(src, '/', '\', 'g')
+    let dest = substitute(dest, '/', '\', 'g')
+    let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
+    call system(cmd_exe . 'copy /y ' . src . ' ' . dest)
+    return !v:shell_error
+  endfunction
+else
+  function! s:copy_exe()
+    throw 'vital: System.File.copy_exe(): your platform is not supported'
+  endfunction
+endif
+
+" Copy a file.
+" Implemented by pure Vim script.
+function! s:copy_vim(src, dest) "{{{
+  let ret = writefile(readfile(a:src, "b"), a:dest, "b")
+  if ret == -1
+    return 0
+  endif
+  return 1
+endfunction "}}}
+
+" mkdir() but does not throw an exception.
+" Returns true if success.
+" Returns false if failure.
+function! s:mkdir_nothrow(...) "{{{
+  try
+    return call('mkdir', a:000)
+  catch
+    return 0
+  endtry
+endfunction "}}}
+
+
+" Delete a file/directory.
+if s:is_unix
+  function! s:rmdir(path, ...)
+    let flags = a:0 ? a:1 : ''
+    let cmd = flags =~# 'r' ? 'rm -r' : 'rmdir'
+    let cmd .= flags =~# 'f' && cmd ==# 'rm -r' ? ' -f' : ''
+    let ret = system(cmd . ' ' . shellescape(a:path))
+    if v:shell_error
+      let ret = iconv(ret, 'char', &encoding)
+      throw substitute(ret, '\n', '', 'g')
+    endif
+  endfunction
+
+elseif s:is_windows
+  function! s:rmdir(path, ...)
+    let flags = a:0 ? a:1 : ''
+    if &shell =~? "sh$"
+      let cmd = flags =~# 'r' ? 'rm -r' : 'rmdir'
+      let cmd .= flags =~# 'f' && cmd ==# 'rm -r' ? ' -f' : ''
+      let ret = system(cmd . ' ' . shellescape(a:path))
+    else
+      " 'f' flag does not make sense.
+      let cmd = 'rmdir /Q'
+      let cmd .= flags =~# 'r' ? ' /S' : ''
+      let ret = system(cmd . ' "' . a:path . '"')
+    endif
+    if v:shell_error
+      let ret = iconv(ret, 'char', &encoding)
+      throw substitute(ret, '\n', '', 'g')
+    endif
+  endfunction
+
+else
+  function! s:rmdir(...)
+    throw 'vital: System.File.rmdir(): your platform is not supported'
+  endfunction
+endif
+
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/autoload/vital/riv_vim.vital
+++ b/autoload/vital/riv_vim.vital
@@ -1,0 +1,4 @@
+riv_vim
+4724200
+
+System.File

--- a/doc/riv_instruction.rst
+++ b/doc/riv_instruction.rst
@@ -1117,6 +1117,9 @@ A window for helping project management.
   + ``<Enter>`` or Double Click to jump to the item.
   + ``<Esc>`` or ``q`` to quit the window
 
+    Set '`g:riv_todo_helper_ignore_done`_' to 1 to ignore TODOs that are marked
+    as DONE in the display.
+
 Todo Helper
 """""""""""
 
@@ -1838,6 +1841,10 @@ Options
 |                                            | - %t is the section title                              |
 +--------------------------------------------+--------------------------------------------------------+
 | _`g:riv_fuzzy_help`                        | Fuzzy searching in helper.                             |
+|                                            |                                                        |
+| 0                                          |                                                        |
++--------------------------------------------+--------------------------------------------------------+
+| _`g:riv_todo_helper_ignore_done`           | Ignore TODOs that are marked as DONE in helper.        |
 |                                            |                                                        |
 | 0                                          |                                                        |
 +--------------------------------------------+--------------------------------------------------------+


### PR DESCRIPTION
I suppose that files that are in the build_path should NOT be cached.

Before applying the patch, the :RivHelpTodo command shows an empty list. This error seems to be introduced in commit `a2334f7b98`

Thank you for this wonderful vim plugin.
