### PR TITLE
Add spacing when creating a new link

### DIFF
--- a/autoload/riv/create.vim
+++ b/autoload/riv/create.vim
@@ -175,7 +175,7 @@ fun! riv#create#link(...) range "{{{
         let idx  = obj.start + 1
         let end  = obj.end + 1
     else
-        let word = input("Input link name:")
+        let word = input("Input link name: ")
         if word =~ '^\s*$' | return | endif
         let idx = col
         let end = col
@@ -195,7 +195,7 @@ fun! riv#create#link(...) range "{{{
         let [ref, tar, loc] = s:expand_link(word)
     endif
 
-    let loc = input("Input link location of '". ref . "':\n", loc, "file")
+    let loc = input("\nInput link location of '". ref . "':\n", loc, "file")
 
     if loc =~ '^\s*$' | return | endif
 


### PR DESCRIPTION
This adds a space when prompting for the link's name, and  adds a newline between the link name input and the next prompt.

Without this extra spacing, the prompts look like

```
Input link name:GoogleInput link location of 'Google_':
http://google.com
```

and afterwards,

```
Input link name: Google
Input link location of 'Google_':
http://google.com
```
