### PR TITLE
Fix conversion in windows

### DIFF
--- a/autoload/riv/publish.vim
+++ b/autoload/riv/publish.vim
@@ -211,7 +211,7 @@ fun! s:convert(options) "{{{
 
     call s:sys( exe." ". style ." " . syn . "  " . args . " "
                 \.shellescape(input) 
-                \." > ".shellescape(output) )
+                \." ".shellescape(output) )
     if o_ft=='pdf'
         " See :Man pdflatex for option details
         if executable('pdflatex')


### PR DESCRIPTION
Docutils' rst conversion scripts support a destination option:

  Usage
  =====
    rst2html.py [options] [<source> [<destination>]]

Thus, you can drop the output forward in the conversion call. This
should fix problems with the conversion call on windows platform.

Tested with docutils-0.14 on win10-v1607-b14393.693