### PR TITLE
Detect different kind of docstrings in Python

### DIFF
--- a/after/syntax/python.vim
+++ b/after/syntax/python.vim
@@ -29,7 +29,7 @@ if g:riv_python_rst_hl == 1
     syn include @python_rst <sfile>:p:h:h:h/syntax/rst.vim
     syn include @python_rst <sfile>:p:h/rst.vim
     syn region pythonRstString matchgroup=pythonString
-        \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
+        \ start=+[bBfFrRuU]\{0,2}\z('''\|"""\)+ end="\z1" keepend
         \ contains=@python_rst,@Spell
     " Restore the previous syntax
     if exists('g:_riv_stored_syntax')


### PR DESCRIPTION
Beside the legacy Unicode literal `u` also recognize
* `r` raw strings
* `b` byte strings
* `f` formatted strings
Combinations of at most 2 are possible.