### PR TITLE
Modified to detect +python3 first

### DIFF
--- a/autoload/riv.vim
+++ b/autoload/riv.vim
@@ -256,12 +256,12 @@ fun! riv#load_conf() "{{{1
     let s:c.doc_path  = fnamemodify(s:autoload_path ,':h').'/doc/'
 
     " Python:
-    if has("python") "{{{
-        let s:c['py'] = "py "
-        let s:c.has_py = 2
-    elseif has("python3")
+    if has("python3") "{{{
         let s:c['py'] = "py3 "
         let s:c.has_py = 3
+    elseif has("python")
+        let s:c['py'] = "py "
+        let s:c.has_py = 2
     else
         let s:c['py'] = "echom 'No Python: ' "
         let s:c.has_py = 0


### PR DESCRIPTION
If Vim's Python external interface is both `+python3(+python3/dyn)` and `+python(+python/dyn)` enabled, many operating systems only enable one interface.

**REF**

https://github.com/vim/vim/issues/1504