### PR TITLE
No-break space added as a delimiter

### DIFF
--- a/syntax/rst.vim
+++ b/syntax/rst.vim
@@ -133,7 +133,7 @@ function! s:DefineOneInlineMarkup(name, start, middle, end, char_left, char_righ
         \ ' start=+' . a:char_left . '\zs' . a:start .
         \ '\ze[^[:space:]' . a:char_right . a:start[strlen(a:start) - 1] . ']+' .
         \ a:middle .
-        \ ' end=+\S' . a:end . '\ze\%($\|\s\|[''")\]}>/:.,;!?\\-]\)+'
+        \ ' end=+\S' . a:end . '\ze\%($\|\s\|[''")\]}>/:.,;!?\\-\u00A0]\)+'
 endfunction
 
 function! s:DefineInlineMarkup(name, start, middle, end)


### PR DESCRIPTION
The construction like
```
:role:`text`
```
did not end up matching, if continued with a no-break space (:role:text`\u00A0`— …). Added no-break space as a constuction delimiter. Probably other unicode space symbols are to be added as well?