### PR TITLE
Fix : get arg for ft converter after ft substitution

### DIFF
--- a/autoload/riv/publish.vim
+++ b/autoload/riv/publish.vim
@@ -156,7 +156,6 @@ fun! s:convert(options) "{{{
     let output = get(a:options, 'output', '')
     let real_file = get(a:options, 'real_file', input)
     let style = ''
-    let args = s:rst_args(ft) 
     
     " For PDF file , we should try rst2latex and rst2xetex.
     if ft=='pdf'
@@ -168,6 +167,7 @@ fun! s:convert(options) "{{{
         let o_ft = 'pdf'
     endif
 
+    let args = s:rst_args(ft) 
 
     let exe = 'rst2'.ft.'2.py'
     if !executable(exe)


### PR DESCRIPTION
`Riv2Pdf` use same converter as `Riv2Latex`. We can expect that it use same
extras args set by `g:riv_rst2latex_args` but it is not the case because
`s:rst_args(ft)` is called before the ft substitution. Fix this by
doing ft substitution beofre args loading.